### PR TITLE
Base64デコードしたByteをObjectに変換するとnull文字がついてしまう不具合を修正。

### DIFF
--- a/src/main/java/mitonize/datastore/okuyama/OkuyamaClientImpl2.java
+++ b/src/main/java/mitonize/datastore/okuyama/OkuyamaClientImpl2.java
@@ -369,7 +369,7 @@ public class OkuyamaClientImpl2 implements OkuyamaClient {
 						if (isNullString(bytes)) {
 							return null;
 						}
-						byte[] b = Base64.decodeBuffer(bytes).array();
+						byte[] b = createFlipedBytes(Base64.decodeBuffer(bytes));
 						return decodeObject(b);
 					} else {
 						bytes.put(ch);
@@ -389,6 +389,17 @@ public class OkuyamaClientImpl2 implements OkuyamaClient {
 			}
 			buffer.flip();
 		}
+	}
+	
+	/**
+	 * ByteBuffer内のlimitまでのbyteを生成する
+	 * @param buffer
+	 * @return ByteBuffer内のlimitまでのbyte
+	 */
+	static byte[] createFlipedBytes(ByteBuffer buffer){
+		byte[] bytes = new byte[buffer.limit()];
+		buffer.get(bytes);
+		return bytes;
 	}
 	
 	/**

--- a/src/test/java/mitonize/datastore/okuyama/OkuyamaClientImplTest.java
+++ b/src/test/java/mitonize/datastore/okuyama/OkuyamaClientImplTest.java
@@ -1,0 +1,26 @@
+package mitonize.datastore.okuyama;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+
+import mitonize.datastore.Base64;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class OkuyamaClientImplTest {
+
+	@Test
+	public void test() {
+		Charset cs = Charset.forName("UTF-8");
+		String str = "abcd";
+		ByteBuffer enc = Base64.encodeBuffer(cs.encode(str));
+		System.out.println(cs.decode(enc).toString());
+		enc.flip();
+
+		ByteBuffer res = Base64.decodeBuffer(enc);
+		Assert.assertEquals(6, res.array().length);
+
+		Assert.assertEquals(4, OkuyamaClientImpl2.createFlipedBytes(res).length);
+	}
+}


### PR DESCRIPTION
原因：ByteBuffer#array()では、limitではなくcamacityを基準にbyte[]に変換するため
null文字もbyteに変換してしまうため

ローカルの別プロジェクトでクライアントが正常に利用できることを確認しましたが、
Junitが通せなかったので、Junitで確認いただければ幸いです。
